### PR TITLE
Fixed file upload to use FAL folder & storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This is the Default Setting:
 module.tx_xlsimport {
 	settings {
 		allowedTables = tt_address
+		# {storageUid}:{folderIdentifier} eg: 1:user_upload/data/import
+		uploadFolder = 1:user_upload/tx_xlsimport
+		# replace | rename | cancel
+		duplicationBehavior = rename
 	}
 }
 ```


### PR DESCRIPTION
Issue on default TYPO3 10.4 respecting FAL file placement. (uploads/ out of scope TYPO3 rejecting path)
Changed to use resourceFactory and folder->addFile to handle renaming and move through TYPO3.