### PR TITLE
Add field "pid" if no TCA columns configuration exists for selected table

### DIFF
--- a/Classes/Controller/XlsimportController.php
+++ b/Classes/Controller/XlsimportController.php
@@ -170,6 +170,15 @@ class XlsimportController extends ActionController
             ]
         ];
         $tca = array_merge($uidConfig, $GLOBALS['TCA'][$table]['columns']);
+	    
+        if(!array_key_exists('pid',$GLOBALS['TCA'][$table]['columns'])) {
+            $pidConfig = [
+                'pid' => [
+                    'label' => 'pid'
+                ]
+            ];
+            $tca = array_merge($uidConfig, $pidConfig, $GLOBALS['TCA'][$table]['columns']);
+        }
 
         $hasPasswordField = false;
         $passwordFields = [];


### PR DESCRIPTION
While field "pid" has been configured in TCA columns for table "tt_address", this is not the case for other tables like "pages" or "tt_content". In these cases the field array for the fields available for selection is extended by the field "pid" to make it available for selection when uploading data.