### PR TITLE
[!!!][BUGFIX] #58 Undefined array key  "label"

### DIFF
--- a/Classes/Controller/DataSheetImportController.php
+++ b/Classes/Controller/DataSheetImportController.php
@@ -470,10 +470,12 @@ final class DataSheetImportController
             if (!AccessUtility::isAllowedField($table, $field)) {
                 unset($tca[$field]);
             } else {
-                try {
-                    $label = $this->languageService->sL($column['label']);
-                } catch ( InvalidArgumentException $e) {
-                    $label = $column['label'];
+                $label = '';
+                if (isset($column['label'])) {
+                    $label = $this->languageService->sL((string)$column['label']);
+                    if (empty($label)) {
+                        $label = ((string)$column['label']);
+                    }
                 }
                 if (empty($label)) {
                     $label = '[' . $field . ']';


### PR DESCRIPTION
Breaking-Changes:
* If the caching framework is set up in a faulty way, this might lead to an InvalidArgumentException. But it wouldn't be the only case, and should break in this scenario

Tasks:
* add check for existence of the key 'label;
* removed try/catch block for InvalidArgumentException as it is not directly thrown by the LanguageService as an Error

Resolves: #58
Releases: main