### PR TITLE
[TASK] Cleanup `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,114 +1,88 @@
 {
-	"name": "sudhaus7/xlsimport",
-	"description": "(Sudhaus7) XLS Importer",
-	"type": "typo3-cms-extension",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Frank Berger",
-			"role": "Developer",
-			"email": "fberger@sudhaus7.de",
-			"homepage": "https://code711.de/"
-		},
-		{
-			"name": "Markus Hofmann",
-			"role": "Developer",
-			"email": "typo3@calien.de"
-		},
-		{
-			"name": "Daniel Simon",
-			"role": "Developer",
-			"email": "dsimon@code711.de"
-		}
-	],
-	"support": {
-		"issues": "https://github.com/sudhaus7/typo3-xlsimport/issues",
-		"source": "https://github.com/sudhaus7/typo3-xlsimport",
-		"docs": "https://docs.typo3.org/p/sudhaus7/xlsimport/3.0/en-us/Index.html"
-	},
-	"require": {
-		"php": "^8.2 || ^8.3 || ^8.4",
-		"ext-json": "*",
-		"phpoffice/phpspreadsheet": "^1.29",
-		"typo3/cms-core": "^13.4"
-	},
-	"require-dev": {
-		"ssch/typo3-rector": "*",
-		"saschaegerer/phpstan-typo3": "*",
-		"armin/editorconfig-cli": "^1.8 || ^2.0",
-		"codeception/codeception": "*",
-		"codeception/phpbuiltinserver": "*",
-		"friendsofphp/php-cs-fixer": "^3.46",
-
-		"friendsoftypo3/tt-address": "^8 || ^9",
-		"helhum/typo3-console": "^7.1 || ^8.1",
-		"phpstan/phpstan": "*",
-		"phpstan/phpstan-phpunit": "*",
-		"phpunit/phpunit": "^9.6.7 || ^10.1",
-		"typo3/cms-backend": "^13.4",
-		"typo3/cms-composer-installers": "v4.0.0-RC1 || ^5.0",
-		"typo3/cms-info": "^13.4",
-		"typo3/cms-install": "^13.4",
-		"typo3/cms-lowlevel": "^13.4",
-		"typo3/cms-setup": "^13.4",
-		"typo3/cms-tstemplate": "^13.4",
-		"typo3/testing-framework": "^7.0 || ^8.0 || ^9.0"
-	},
-	"suggest": {
-		"friendsoftypo3/tt-address": "*"
-	},
-	"extra": {
-		"typo3/cms": {
-			"extension-key": "xlsimport",
-			"cms-package-dir": "{$vendor-dir}/typo3/cms",
-			"web-dir": ".Build/public"
-		}
-	},
-	"autoload": {
-		"psr-4": {
-			"SUDHAUS7\\Xlsimport\\": "Classes/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"SUDHAUS7\\Xlsimport\\Tests\\": "Tests/"
-		}
-	},
-	"config": {
-		"preferred-install": {
-			"*": "dist"
-		},
-		"sort-packages": true,
-		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin",
-		"allow-plugins": {
-			"typo3/cms-composer-installers": true,
-			"typo3/class-alias-loader": true
-		}
-	},
-	"scripts": {
-		"ec:check": "ec -v -n --no-progress -e'var/log' -e'.Build' -e'.ddev' -e'phpstan-baseline.neon'",
-		"ec:fix": "ec -v -n --fix -e'var/log' -e'.Build' -e'.ddev'",
-		"cs:check": "php-cs-fixer fix --config .config/.php-cs-rules.php --ansi --diff --verbose --dry-run",
-		"cs:fix": "php-cs-fixer fix --config .config/.php-cs-rules.php --ansi",
-		"analyze:php": "phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=.config/phpstan.neon",
-		"test:php": [
-			"@test:php:unit",
-			"@test:php:functional"
-		],
-		"test:php:unit": ".Build/bin/phpunit --colors=always --configuration .config/phpunit-unit.xml",
-		"test:php:functional": ".Build/bin/phpunit --colors=always  --configuration .config/phpunit-functional.xml",
-		"post-autoload-dump": [
-			"mkdir -p .Build/public/typo3conf/ext/",
-			"[ -L .Build/public/typo3conf/ext/xlsimport ] || ln -snvf ../../../../. .Build/public/typo3conf/ext/xlsimport"
-		],
-		"prepare-release": [
-			"rm -rf .run",
-			"rm -rf .config",
-			"composer remove typo3/cms-core --no-progress --no-update",
-			"composer config vendor-dir Resources/Private/Php",
-			"composer install --no-dev --ignore-platform-reqs --no-progress",
-			"composer require 'typo3/cms-core:^13.4' --no-progress --no-update"
-		]
-	}
+  "name": "sudhaus7/xlsimport",
+  "description": "(Sudhaus7) XLS Importer",
+  "type": "typo3-cms-extension",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Frank Berger",
+      "role": "Developer",
+      "email": "fberger@sudhaus7.de",
+      "homepage": "https://code711.de/"
+    },
+    {
+      "name": "Markus Hofmann",
+      "role": "Developer",
+      "email": "typo3@calien.de"
+    },
+    {
+      "name": "Daniel Simon",
+      "role": "Developer",
+      "email": "dsimon@code711.de"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/sudhaus7/typo3-xlsimport/issues",
+    "source": "https://github.com/sudhaus7/typo3-xlsimport",
+    "docs": "https://docs.typo3.org/p/sudhaus7/xlsimport/3.0/en-us/Index.html"
+  },
+  "require": {
+    "php": "^8.2 || ^8.3 || ^8.4",
+    "ext-json": "*",
+    "phpoffice/phpspreadsheet": "^1.29",
+    "typo3/cms-core": "^13.4"
+  },
+  "require-dev": {
+    "ssch/typo3-rector": "*",
+    "saschaegerer/phpstan-typo3": "*",
+    "armin/editorconfig-cli": "^1.8 || ^2.0",
+    "codeception/codeception": "*",
+    "codeception/phpbuiltinserver": "*",
+    "friendsofphp/php-cs-fixer": "^3.46",
+    "friendsoftypo3/tt-address": "^8 || ^9",
+    "helhum/typo3-console": "^7.1 || ^8.1",
+    "phpstan/phpstan": "*",
+    "phpstan/phpstan-phpunit": "*",
+    "phpunit/phpunit": "^9.6.7 || ^10.1",
+    "typo3/cms-backend": "^13.4",
+    "typo3/cms-composer-installers": "v4.0.0-RC1 || ^5.0",
+    "typo3/cms-info": "^13.4",
+    "typo3/cms-install": "^13.4",
+    "typo3/cms-lowlevel": "^13.4",
+    "typo3/cms-setup": "^13.4",
+    "typo3/cms-tstemplate": "^13.4",
+    "typo3/testing-framework": "^7.0 || ^8.0 || ^9.0"
+  },
+  "suggest": {
+    "friendsoftypo3/tt-address": "*"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "xlsimport",
+      "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "web-dir": ".Build/public"
+    }
+  },
+  "autoload": {
+    "psr-4": {
+      "SUDHAUS7\\Xlsimport\\": "Classes/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "SUDHAUS7\\Xlsimport\\Tests\\": "Tests/"
+    }
+  },
+  "config": {
+    "preferred-install": {
+      "*": "dist"
+    },
+    "sort-packages": true,
+    "vendor-dir": ".Build/vendor",
+    "bin-dir": ".Build/bin",
+    "allow-plugins": {
+      "typo3/cms-composer-installers": true,
+      "typo3/class-alias-loader": true
+    }
+  }
 }


### PR DESCRIPTION
Looking into the `composer.json` file it is more then
obvious that the file has been edited manually in the
past, which is considerable bad-practise. To mitigate
that this change cleans the `composer.json` file:

* Remove all `composer.json` scripts because they are
  outdated related to the configuration or using more
  older and different configuration then `runTests.sh`
  and follows therefore the lived best-practice define
  and maintain scripts in one-place. Composer scripts
  should not exists at all, but that's another topic.

* Remove really outdated and duplicated phpunit and
  phpstan configuration in favour of the integration
  within `Build/Scripts/runTests.sh` to ensure same
  tooling and configuration in all environments.

Used command(s):

```shell
cat <<< $(jq 'del(.scripts)' composer.json) > composer.json \
&& rm -rf .config
```
