### PR TITLE
[TASK] Mitigate request parsedBody object issue

### DIFF
--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,14 +1,3 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Cannot access offset ''action'' on array\|object\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../../../Classes/Controller/DataSheetImportController.php
-
-		-
-			message: '#^Cannot access offset ''id'' on array\|object\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../../../Classes/Controller/DataSheetImportController.php
+	ignoreErrors: []
 

--- a/Classes/Controller/DataSheetImportController.php
+++ b/Classes/Controller/DataSheetImportController.php
@@ -53,7 +53,7 @@ final class DataSheetImportController
      */
     public function handleRequest(ServerRequestInterface $request): ResponseInterface
     {
-        $action = (string)($request->getQueryParams()['action'] ?? $request->getParsedBody()['action'] ?? 'index');
+        $action = $this->extractActionParamValue($request);
 
         /**
          * Define allowed actions
@@ -376,7 +376,7 @@ final class DataSheetImportController
      */
     private function checkAccessForPage(ServerRequestInterface $request): int
     {
-        $pageIdString = ($request->getQueryParams()['id'] ?? $request->getParsedBody()['id'] ?? 0);
+        $pageIdString = $this->extractIdParamValue($request);
 
         $pageId = (int)$pageIdString;
 
@@ -559,5 +559,36 @@ final class DataSheetImportController
     {
         $temporaryPath = Environment::getVarPath() . '/transient/';
         return sprintf('%s%s', $temporaryPath, $jsonFileName);
+    }
+
+    private function extractActionParamValue(ServerRequestInterface $request): string
+    {
+        if (isset($request->getQueryParams()['action'])
+            && is_string($request->getQueryParams()['action'])
+            && $request->getQueryParams()['action'] !== ''
+        ) {
+            return $request->getQueryParams()['action'];
+        }
+        if (is_array($request->getParsedBody())
+            && isset($request->getParsedBody()['action'])
+            && is_string($request->getParsedBody()['action'])
+            && $request->getParsedBody()['action'] !== ''
+        ) {
+            return $request->getParsedBody()['action'];
+        }
+        return 'index';
+    }
+
+    private function extractIdParamValue(ServerRequestInterface $request): int
+    {
+        if (isset($request->getQueryParams()['id'])) {
+            return (int)$request->getQueryParams()['id'];
+        }
+        if (is_array($request->getParsedBody())
+            && isset($request->getParsedBody()['id'])
+        ) {
+            return (int)$request->getParsedBody()['id'];
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
In general the parsed body could be an object, which is
moste unlikly in TYPO3 backend context and special for
our own routing. To make phpstan happy, introduce two
private methods to the backend controller extracting
required query param or post data values with strict
typing.

Used command(s):

```shell
Build/Scripts/runTests.sh -p 8.2 -t 13 \
  -s phpstanGenerateBaseline
```
