### PR TITLE
[TASK] Enable functional tests in GitHub actions

### DIFF
--- a/.github/workflows/test13.yml
+++ b/.github/workflows/test13.yml
@@ -43,21 +43,20 @@ jobs:
       - name: Unit Tests (randomized)
         run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -s unitRandom
 
-# @todo Functional tests disabled for now until deprecations like TCA migration has been handled correctly.
-#      - name: Functional Tests with mariadb and mysqli
-#        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mariadb -a mysqli -s functional
-#
-#      - name: Functional Tests with mariadb and pdo_mysql
-#        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mariadb -a pdo_mysql -s functional
-#
-#      - name: Functional Tests with mysql and mysqli
-#        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mysql -a mysqli -s functional
-#
-#      - name: Functional Tests with mysql and pdo_mysql
-#        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mysql -a pdo_mysql -s functional
-#
-#      - name: Functional Tests with postgres
-#        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d postgres -s functional
-#
-#      - name: Functional Tests with sqlite
-#        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d sqlite -s functional
+      - name: Functional Tests with mariadb and mysqli
+        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mariadb -a mysqli -i 10.4 -s functional
+
+      - name: Functional Tests with mariadb and pdo_mysql
+        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mariadb -a pdo_mysql -i 10.6 -s functional
+
+      - name: Functional Tests with mysql and mysqli
+        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mysql -a mysqli -i 8.0 -s functional
+
+      - name: Functional Tests with mysql and pdo_mysql
+        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d mysql -a pdo_mysql -i 8.4 -s functional
+
+      - name: Functional Tests with postgres
+        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d postgres -i 10 -s functional
+
+      - name: Functional Tests with sqlite
+        run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }} -d sqlite -s functional


### PR DESCRIPTION
Executing functional tests has been disabled within
the GitHub action workflow for TYPO3 based testing,
mainly due to issues with the setup and dependencies.

These issues has been fixed meanwhile and are now
enabled again to have them as quality measurement
for pull-requests in place.

Better be hard than dead !
