### PR TITLE
[TASK] Set branch-alias for master branch

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -405,7 +405,7 @@ fi
 
 handleDbmsOptions
 
-COMPOSER_ROOT_VERSION="2.x.x-dev"
+COMPOSER_ROOT_VERSION="6.x.x-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 USERSET=""

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
 					"autoload-dev"
 				]
 			}
+		},
+		"branch-alias": {
+			"dev-master": "6.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
Current master branch is for the 6.x development
of the extension but misses to configure matching
composer branch alias.

To help with constraint selection in project and
to avoid pure branch names in constraints this
change defines now a development version constraint
for the master branch and also adjusts the related
composer root version in `Build/Scripts/runTests.sh`.

Used command(s):

```shell
Build/Scripts/runTests.sh -p 8.2 -t 13 \
  -s composer -- config \
    "extra"."branch-alias"."dev-master" "6.x-dev"
```
