### PR TITLE
[TASK] Execute GitHub action after merge/push on master branch

### DIFF
--- a/.github/workflows/test13.yml
+++ b/.github/workflows/test13.yml
@@ -1,6 +1,9 @@
 name: tests13
 
 on:
+  push:
+    branches:
+      - "master"
   pull_request:
   schedule:
     - cron:  '42 5 * * *'


### PR DESCRIPTION
This change adjusts the GitHub action workflow definition
to execute pipeline for the master branch on pushes, which
includes direct pushes or push of merged pull-requests.
