### PR TITLE
[TASK] Improve included `ddev` instance configuration

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,69 +1,108 @@
 name: typo3-xlsimport
 type: typo3
 docroot: .Build/public
-php_version: "8.1"
+php_version: "8.2"
 webserver_type: nginx-fpm
-router_http_port: "80"
-router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 database:
-  type: mariadb
-  version: "10.4"
-nfs_mount_enabled: false
-mutagen_enabled: false
+    type: mariadb
+    version: "10.4"
+fail_on_hook_fail: true
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
 nodejs_version: "16"
+corepack_enable: false
+hooks:
+  post-start:
+    - exec-host: |
+        DDEV_CURRENT_TABLES="$( ddev mysql -e 'SHOW TABLES;' )"
+        if [[ -n "${DDEV_CURRENT_TABLES}" ]]; then
+          echo '>> system already setup'
+          ddev launch /typo3
+          ddev launch /styleguide-demo-1
+        else
+          echo '>> no tables found, setup system' \
+            && Build/Scripts/runTests.sh -s composerUpdate \
+            && ddev typo3 setup --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db --admin-username=john-doe --admin-user-password='John-Doe-1701D.' --admin-email='john.doe@example.com' --project-name='typo3-xlsimport' --no-interaction --server-type=apache --force \
+            && ddev typo3 setup:begroups:default --groups=Both \
+            && ddev typo3 styleguide:generate --create -- frontend-systemplate \
+            && ddev mysql -e 'UPDATE pages SET hidden=0 WHERE hidden=1;' \
+            && ddev restart || true
+        fi
 
-# Key features of ddev's config.yaml:
+# Key features of DDEV's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides
 #   http://projectname.ddev.site and https://projectname.ddev.site
+# If the name is omitted, the project will take the name of the enclosing directory,
+# which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
+# information on the different project types
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.4"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"
+# php_version: "8.3"  # PHP version to use, "5.6" through "8.4"
 
 # You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to ddev's' behavior,
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
 # so this can break upgrades.
 
 # webimage: <docker_image>  # nginx/php docker image.
 
 # database:
-#   type: <dbtype> # mysql, mariadb
-#   version: <version> # database version, like "10.3" or "8.0"
-# Note that mariadb_version or mysql_version from v1.18 and earlier
-# will automatically be converted to this notation with just a "ddev config --auto"
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.11" or "8.0"
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
+#   MySQL versions can be 5.5-8.0, 8.4
+#   PostgreSQL versions can be 9-17
 
-# router_http_port: <port>  # Port to be used for http (defaults to port 80)
-# router_https_port: <port> # Port for https (defaults to 443)
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
 
-# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
 # Note that for most people the commands
-# "ddev xdebug" to enable xdebug and "ddev xdebug off" to disable it work better,
-# as leaving xdebug enabled all the time is a big performance hit.
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
 
-# xhprof_enabled: false  # Set to true to enable xhprof and "ddev start" or "ddev restart"
+# xhgui_https_port: 8142
+# Can be used to change the router https port for xhgui application
+# Very rarely used
+
+# xhgui_http_port: 8143
+# Can be used to change the router http port for xhgui application
+# Very rarely used
+
+# host_xhgui_port: 8142
+# Can be used to change the host binding port of the xhgui
+# application. Rarely used; only when port conflict and
+# bind_all_ports is used (normally with router disabled)
+
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
 # Note that for most people the commands
-# "ddev xhprof" to enable xhprof and "ddev xhprof off" to disable it work better,
-# as leaving xhprof enabled all the time is a big performance hit.
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
 
-# webserver_type: nginx-fpm  # or apache-fpm
+# xhprof_mode: [prepend|xhgui|global]
+# Set to "xhgui" to enable XHGui features
+# "xhgui" will become default in a future major release
+
+# webserver_type: nginx-fpm, apache-fpm, generic
 
 # timezone: Europe/Berlin
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
 # This is the timezone used in the containers and by PHP;
 # it can be set to any valid timezone,
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # For example Europe/Dublin or MST7MDT
 
 # composer_root: <relative_path>
-# Relative path to the composer root directory from the project root. This is
+# Relative path to the Composer root directory from the project root. This is
 # the directory which contains the composer.json and where all Composer related
 # commands are executed.
 
@@ -76,12 +115,17 @@ nodejs_version: "16"
 #   - preview
 #   - snapshot
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev debug refresh".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
 
-# nodejs_version: "16"
-# change from the default system Node.js version to another supported version, like 12, 14, 17, 18.
-# Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
-# Node.js version, including v6, etc.
+# nodejs_version: "22"
+# change from the default system Node.js version to any other version.
+# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
+# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
+# can specify any version, and is more robust than using 'nvm'.
+
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
 
 # additional_hostnames:
 #  - somename
@@ -95,10 +139,26 @@ nodejs_version: "16"
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
 
-# upload_dir: custom/upload/dir
-# would set the destination path for ddev import-files to <docroot>/custom/upload/dir
-# When mutagen is enabled this path is bind-mounted so that all the files
-# in the upload_dir don't have to be synced into mutagen
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.22.4"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
 
 # working_dir:
 #   web: /var/www/html
@@ -107,20 +167,25 @@ nodejs_version: "16"
 # These values specify the destination directory for ddev ssh and the
 # directory in which commands passed into ddev exec are run.
 
-# omit_containers: [db, dba, ddev-ssh-agent]
+# omit_containers: [db, ddev-ssh-agent]
 # Currently only these containers are supported. Some containers can also be
 # omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
-# the "db" container, several standard features of ddev that access the
+# the "db" container, several standard features of DDEV that access the
 # database container will be unusable. In the global configuration it is also
 # possible to omit ddev-router, but not here.
 
-# nfs_mount_enabled: false
-# Great performance improvement but requires host configuration first.
-# See https://ddev.readthedocs.io/en/stable/users/performance/#using-nfs-to-mount-the-project-into-the-container
-
-# mutagen_enabled: false
-# Performance improvement using mutagen asynchronous updates.
-# See https://ddev.readthedocs.io/en/latest/users/performance/#using-mutagen
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
 # Decide whether 'ddev start' should be interrupted by a failing hook
@@ -141,20 +206,12 @@ nodejs_version: "16"
 # The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
 # unless explicitly specified.
 
-# phpmyadmin_port: "8036"
-# phpmyadmin_https_port: "8037"
-# The PHPMyAdmin ports can be changed from the default 8036 and 8037
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
 
-# host_phpmyadmin_port: "8036"
-# The phpmyadmin (dba) port is not normally bound on the host at all, instead being routed
-# through ddev-router, but it can be specified and bound.
-
-# mailhog_port: "8025"
-# mailhog_https_port: "8026"
-# The MailHog ports can be changed from the default 8025 and 8026
-
-# host_mailhog_port: "8025"
-# The mailhog port is not normally bound on the host at all, instead being routed
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
 # webimage_extra_packages: [php7.4-tidy, php-bcmath]
@@ -177,32 +234,32 @@ nodejs_version: "16"
 
 # ngrok_args: --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs#http or run "ngrok http -h"
+# https://ngrok.com/docs/agent/config/v3/#agent-configuration or run "ngrok http -h"
 
 # disable_settings_management: false
-# If true, ddev will not create CMS-specific settings files like
-# Drupal's LocalConfiguration.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
 # In this case the user must provide all such settings.
 
 # You can inject environment variables into the web container with:
 # web_environment:
-# - SOMEENV=somevalue
-# - SOMEOTHERENV=someothervalue
+#     - SOMEENV=somevalue
+#     - SOMEOTHERENV=someothervalue
 
 # no_project_mount: false
-# (Experimental) If true, ddev will not mount the project into the web container;
+# (Experimental) If true, DDEV will not mount the project into the web container;
 # the user is responsible for mounting it manually or via a script.
 # This is to enable experimentation with alternate file mounting strategies.
 # For advanced users only!
 
 # bind_all_interfaces: false
 # If true, host ports will be bound on all network interfaces,
-# not just the localhost interface. This means that ports
+# not the localhost interface only. This means that ports
 # will be available on the local network if the host firewall
 # allows it.
 
 # default_container_timeout: 120
-# The default time that ddev waits for all containers to become ready can be increased from
+# The default time that DDEV waits for all containers to become ready can be increased from
 # the default 120. This helps in importing huge databases, for example.
 
 #web_extra_exposed_ports:
@@ -215,12 +272,16 @@ nodejs_version: "16"
 #  https_port: 4000
 #  http_port: 3999
 # Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
 # The port behavior on the ddev-webserver must be arranged separately, for example
 # using web_extra_daemons.
 # For example, with a web app on port 3000 inside the container, this config would
 # expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
 # web_extra_exposed_ports:
-#  - container_port: 3000
+#  - name: myapp
+#    container_port: 3000
 #    http_port: 9998
 #    https_port: 9999
 
@@ -235,10 +296,10 @@ nodejs_version: "16"
 # override_config: false
 # By default, config.*.yaml files are *merged* into the configuration
 # But this means that some things can't be overridden
-# For example, if you have 'nfs_mount_enabled: true'' you can't override it with a merge
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
-# 'nfs_mount_enabled: false' can override the existing values, and
+# 'use_dns_when_possible: false' can override the existing values, and
 # hooks:
 #   post-start: []
 # or
@@ -248,8 +309,8 @@ nodejs_version: "16"
 # can have their intended affect. 'override_config' affects only behavior of the
 # config.*.yaml file it exists in.
 
-# Many ddev commands can be extended to run tasks before or after the
-# ddev command is executed, for example "post-start", "post-import-db",
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
 # See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define

--- a/.ddev/homeadditions/.bash_aliases
+++ b/.ddev/homeadditions/.bash_aliases
@@ -1,0 +1,2 @@
+
+alias ll="ls -lhA"

--- a/.ddev/homeadditions/.bashrc.d/paths.sh
+++ b/.ddev/homeadditions/.bashrc.d/paths.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export PATH=$PATH:/var/www/html/.Build/bin
+

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,5 @@ tests/_output/*
 !/ext_*.php
 
 /var
-/vendor
 /config
-/.ddev
 /.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -72,6 +72,52 @@ hope to address this in a future update.
 - support for related data as far as it is modelled in the TCA
 - support for import-presets or templates for recurring import tasks
 
+### Local development
+
+#### Local development environment with `ddev`
+
+This extension repository includes a `ddev` instance configuration matching the development
+requirements and is setup to provide and easy and simple development experience for people,
+which wants to contribute or play around.
+
+That means, thatn on a simple `ddev start` the environment is checked and the TYPO3 instance
+configured (setup) against ddev with a generic admin user along with creating pages tree for
+the backend using `typo3/cms-styleguide` and the included generator.
+
+**Start**
+
+```shell
+ddev start
+```
+
+**Full reset (destroy)**
+
+```shell
+ddev stop -ROU \
+  && git clean -xdf -e '.idea'
+```
+
+**Recreate instance**
+
+```shell
+ddev stop -ROU \
+  && git clean -xdf -e '.idea' \
+  && ddev start
+```
+
+To simplify the setup, a generic admin user is created:
+
+| type | username | password        | email                |
+|------|----------|-----------------|----------------------|
+| BE   | john-doe | John-Doe-1701D. | john.doe@example.com |
+
+with following urls:
+
+| url                                                  | command                         | description                  |
+|------------------------------------------------------|---------------------------------|------------------------------|
+| https://typo3-xlsimport.ddev.site/typo3/             | ddev launch /typo3/             | Open the TYPO3 backend       |
+| https://typo3-xlsimport.ddev.site/styleguide-demo-1/ | ddev launch /styleguide-demo-1/ | Open the styleguide frontend |
+
 ### Changes in v5.0
 
 * removed TypoScript support, as TypoScript is frontend related

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
 		"typo3/cms-install": "^13.4",
 		"typo3/cms-lowlevel": "^13.4",
 		"typo3/cms-setup": "^13.4",
+		"typo3/cms-styleguide": "^13.4",
 		"typo3/cms-tstemplate": "^13.4",
 		"typo3/testing-framework": "^9.2"
 	},


### PR DESCRIPTION
For development purpose this repository contains a
`ddev` instance configuration to provide a suiting
local development environment. However, it doesn't
align with current branch requirements and besides
that it is not usefull at all right out of the box.

To improve the situation, this change ...

* Updates the `ddev` configuration to align with the
  current minimal requirements, e.g. php version.

* Adds `typo3/cms-styleguide` as dev dependency, which
  provides a generator of pages (frontend).

* Adds `ddev` start hook to bootstrap a full instance
  using `typo3 setup` to configure the instance first
  and `typo3/cms-styleguide` to populate some content.

* Extend `README.md` to add some remarks regarding the
  `ddev` setup and usage.

Used command(s):

```shell
echo '>> Adjust ddev configuration' \
&& ddev config \
  --php-version "8.2" \
  --fail-on-hook-fail \
&& echo '>> Adds typo3/cms-styleguide dependency' \
  && Build/Scripts/runTests.sh -p 8.2 -t 13 \
    -s composer -- require --dev \
    'typo3/cms-styleguide':'^13.4'
```

> [!NOTE]
> Currently no extension specific configurationa are
> added during the automatic setup, for example an
> custom PageTS configuration. This will be added at
> a later point when it is clear how to setup it and
> in which form automatically. Take this for now as
> a `automated as much as possible` and minimize the
> manual steps.
