### PR TITLE
[TASK] Use fixture extension as dev dependency

### DIFF
--- a/Tests/Functional/Fixtures/Extensions/test_example/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_example/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "tests/test_example",
+	"name": "tests/test-example",
 	"description": "Functional test fixture extension",
 	"type": "typo3-cms-extension",
 	"license": "GPL-2.0-or-later",

--- a/Tests/Functional/Service/ImportServiceTest.php
+++ b/Tests/Functional/Service/ImportServiceTest.php
@@ -26,7 +26,7 @@ final class ImportServiceTest extends FunctionalTestCase
      * @var non-empty-string[]
      */
     protected array $testExtensionsToLoad = [
-        'tests/test_example',
+        'tests/test-example',
         'sudhaus7/xlsimport',
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 		"saschaegerer/phpstan-typo3": "^2.1.1",
 		"sbuerk/fixture-packages": "^1.1.3",
 		"ssch/typo3-rector": "*",
+		"tests/test-example": "1.0.0@dev",
 		"typo3/cms-info": "^13.4",
 		"typo3/cms-install": "^13.4",
 		"typo3/cms-lowlevel": "^13.4",
@@ -51,7 +52,8 @@
 		"typo3/testing-framework": "^9.2"
 	},
 	"suggest": {
-		"friendsoftypo3/tt-address": "*"
+		"friendsoftypo3/tt-address": "*",
+		"tests/test-example": "*"
 	},
 	"extra": {
 		"typo3/cms": {
@@ -93,5 +95,18 @@
 			"typo3/class-alias-loader": true,
 			"sbuerk/fixture-packages": true
 		}
-	}
+	},
+	"repositories": {
+		"fixture-ttaddress": {
+			"type": "path",
+			"url": "Tests/Functional/Fixtures/Extensions/test_example",
+			"options": {
+				"versions": {
+					"tests/test-example": "1.0.0"
+				}
+			}
+		}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }


### PR DESCRIPTION
In a recent change a fixture extension has been added
only providing the `tt_address` table and TCA config,
mainly to avoid deprecation from the 3rd party TYPO3
extension during functional tests.

`EXT:xlsimport` provides default PageTS config for
`EXT:tt_address` and would make a development setup
easier.

To combine these points, the fixture extension is
now added as development dependency to have a base
setup for the `ddev` based development environment.

Used command(s):

```shell
Build/Scripts/runTests.sh -p 8.2 -t 13 \
  -s composer -- config \
  "repositories"."fixture-ttaddress" \
  --json '{"type": "path", "url": "Tests/Functional/Fixtures/Extensions/test_example", "options": {"versions": {"tests/test-example": "1.0.0"}}}' \
&& Build/Scripts/runTests.sh -p 8.2 -t 13 \
  -s composer -- config \
  minimum-stability "dev" \
&& Build/Scripts/runTests.sh -p 8.2 -t 13 \
  -s composer -- config \
  prefer-stable true \
&& cat <<< $(
  jq --indent 2 --tab '.suggest."tests/test-example" = "*"' composer.json
) > composer.json \
&& Build/Scripts/runTests.sh -p 8.2 -t 13 \
  -s composer -- require --dev --no-update \
  'tests/test-example':'1.0.0@dev'
```
