### PR TITLE
[BUGFIX] Use correct back-slashes for class namespace in fluid

### DIFF
--- a/Resources/Private/Templates/DataSheetImport/Index.html
+++ b/Resources/Private/Templates/DataSheetImport/Index.html
@@ -14,7 +14,7 @@
     <f:flashMessages queueIdentifier="core.template.flashMessages" />
     <f:be.infobox
         title="{f:translate(key:'importinfo', extensionName: 'xlsimport')}"
-        state="{f:constant(name: 'TYPO3∖CMS∖Fluid∖ViewHelpers∖Be∖InfoboxViewHelper::STATE_INFO')}"
+        state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}"
     >
         <f:translate key="importinfo_format" extensionName="xlsimport" />
         <ul>

--- a/Resources/Private/Templates/DataSheetImport/Upload.html
+++ b/Resources/Private/Templates/DataSheetImport/Upload.html
@@ -13,7 +13,7 @@
     <h1><f:translate key="module_name" extensionName="xlsimport" /> - <f:translate key="prepare" extensionName="xlsimport" /></h1>
     <f:be.infobox
         title="{f:translate(key:'prepareinfo', extensionName: 'xlsimport')}"
-        state="{f:constant(name: 'TYPO3∖CMS∖Fluid∖ViewHelpers∖Be∖InfoboxViewHelper::STATE_INFO')}"
+        state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}"
     >
         <ol>
             <li>{f:translate(key: 'prepareinfo_text', extensionName: 'xlsimport')}</li>


### PR DESCRIPTION
With a recent change fluid templates has been adjusted to use
the `<f:constant />` ViewHelper to access class constants for
use as argument for the `<f:be.infobox />` and the definition
copied from the TYPO3 documentation - which rendered weired
UTF backslashes technical incompatible and leading to following
exception:

```
Class "TYPO3∖CMS∖Fluid∖ViewHelpers∖Be∖InfoboxViewHelper" not found
```

The invalid backslashes are now replaced with correct backslashes
mitigate the issue and get the backend module rendered again.
