### PR TITLE
[TASK] Add default `page.tsconfig` to fixture extension

### DIFF
--- a/Tests/Functional/Fixtures/Extensions/test_example/Configuration/page.tsconfig
+++ b/Tests/Functional/Fixtures/Extensions/test_example/Configuration/page.tsconfig
@@ -1,0 +1,5 @@
+module.tx_xlsimport {
+    settings {
+        allowedTables = tt_address
+    }
+}


### PR DESCRIPTION
The extension provides the test fixture extension
`tests/test-example` which defines the `tt_address`
table and TCA for it as a lightweight testing base,
mitigating 3rd party extension developer maintenance
speed to tackle deprecation.

This change now adds `Configuration/page.tsconfig` to
the fixture extension automatically loaded by TYPO3,
with following default TSConfig:

```
module.tx_xlsimport {
    settings {
        allowedTables = tt_address
    }
}
```

Literally, this eliminates the need to add the TSConfig
manually in a instance when the fixture extension has
been installed.
