### PR TITLE
[BUGFIX] Hide upload form when no allowed tables are configured

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -134,6 +134,15 @@
 				<source>The temporarily saved file was not found. Please try again with upload your data.</source>
 				<target>Die temporär gespeicherte Datei konnte nicht geladen werden. Bitte versuchen Sie einen erneuten Upload.</target>
 			</trans-unit>
+
+			<trans-unit id="uploadForm.no_allowed_tables_available_title">
+				<source>Incomplete configuration</source>
+				<target>Unvollständige Konfiguration</target>
+			</trans-unit>
+			<trans-unit id="uploadForm.no_allowed_tables_available_message">
+				<source>No allowed tables for import configured. Refer documentation for required PageTSConfig configuration.</source>
+				<target>Es wurden keine Tabellen für den Import freigegeben. Bitte schaue in die Dokumentation für die notwendige PageTSConfig Konfiguration.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -109,6 +109,13 @@
 			<trans-unit id="error.jsonFile.message">
 				<source>The temporarily saved file was not found. Please try again with upload your data.</source>
 			</trans-unit>
+
+			<trans-unit id="uploadForm.no_allowed_tables_available_title">
+				<source>Incomplete configuration</source>
+			</trans-unit>
+			<trans-unit id="uploadForm.no_allowed_tables_available_message">
+				<source>No allowed tables for import configured. Refer documentation for required PageTSConfig configuration.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/DataSheetImport/Index.html
+++ b/Resources/Private/Templates/DataSheetImport/Index.html
@@ -26,6 +26,23 @@
             <li>CSV (.csv/.txt)</li>
         </ul>
     </f:be.infobox>
+    <f:if condition="{allowedTables} && {f:count(subject: allowedTables)} > 0">
+        <f:then>
+            <f:render section="uploadForm" arguments="{_all}" />
+        </f:then>
+        <f:else>
+            <f:be.infobox
+                title="{f:translate(key:'uploadForm.no_allowed_tables_available_title', extensionName: 'xlsimport')}"
+                state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_ERROR')}"
+            >
+                <f:translate key="uploadForm.no_allowed_tables_available_message" extensionName="xlsimport" />
+            </f:be.infobox>
+        </f:else>
+    </f:if>
+
+</f:section>
+
+<f:section name="uploadForm">
     <form
         action="{f:be.uri(route: 'web_xlsimport', parameters: '{action: \'upload\', id: \'{page}\'}')}"
         enctype="multipart/form-data"
@@ -74,4 +91,5 @@
         </div>
     </form>
 </f:section>
+
 </html>


### PR DESCRIPTION
When either no `allowedTables` are configured using the documented
`PageTSConfig`, either globally or for the page currently selected,
it does not make sense to provide the import file upload form as it
is not possible to guess any table it should be imported to and lead
to follow up issues.

This change modifies the fluid template checking the count of the
available tables, displaying a error message instead of the upload
form if no tables are allowed. Otherwise the upload form with the
select field for the table is rendered, moved to dedicated section
now.

<img width="725" height="336" alt="image" src="https://github.com/user-attachments/assets/0806dad4-5232-4cab-86ed-689f0c86e1cc" />

<img width="718" height="466" alt="image" src="https://github.com/user-attachments/assets/5d07c703-9a93-4865-9632-299e593032bb" />

