### PR TITLE
[TASK] Prepare for next major `7.x`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -401,7 +401,7 @@ fi
 
 handleDbmsOptions
 
-COMPOSER_ROOT_VERSION="6.x.x-dev"
+COMPOSER_ROOT_VERSION="7.x.x-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 USERSET=""

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -63,7 +63,7 @@ handleDbmsOptions() {
                 exit 1
             fi
             [ -z "${DBMS_VERSION}" ] && DBMS_VERSION="8.0"
-            if ! [[ ${DBMS_VERSION} =~ ^(5.5|5.6|5.7|8.0|8.1|8.2|8.3|8.4)$ ]]; then
+            if ! [[ ${DBMS_VERSION} =~ ^(8.0|8.1|8.2|8.3|8.4)$ ]]; then
                 echo "Invalid combination -d ${DBMS} -i ${DBMS_VERSION}" >&2
                 echo >&2
                 echo "Use \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
@@ -78,7 +78,7 @@ handleDbmsOptions() {
                 exit 1
             fi
             [ -z "${DBMS_VERSION}" ] && DBMS_VERSION="10"
-            if ! [[ ${DBMS_VERSION} =~ ^(9.6|10|11|12|13|14|15|16)$ ]]; then
+            if ! [[ ${DBMS_VERSION} =~ ^(10|11|12|13|14|15|16)$ ]]; then
                 echo "Invalid combination -d ${DBMS} -i ${DBMS_VERSION}" >&2
                 echo >&2
                 echo "Use \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
@@ -223,16 +223,12 @@ Options:
             - 11.3   short-term development series, rolling release
             - 11.4   long-term, maintained until 2029-05
         With "-d mysql":
-            - 5.5   unmaintained since 2018-12
-            - 5.6   unmaintained since 2021-02
-            - 5.7   maintained until 2023-10
             - 8.0   maintained until 2026-04 (default)
             - 8.1   unmaintained since 2023-10
             - 8.2   unmaintained since 2024-01
             - 8.3   maintained until 2024-04
             - 8.4   maintained until 2032-04 LTS
         With "-d postgres":
-            - 9.6   unmaintained since 2021-11-11
             - 10    unmaintained since 2022-11-10 (default)
             - 11    maintained until 2023-11-09
             - 12    maintained until 2024-11-14

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
 			}
 		},
 		"branch-alias": {
-			"dev-master": "6.x-dev"
+			"dev-master": "7.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
- **[TASK] Remove unsupported database versions in `runTests.sh`**
  Related TYPO3 versions supported by the extension version
  currently worked on raised minimal supported db versions,
  which has not been adopted in the `runTests.sh` dispatcher.
  
  This is now done to only allow supported versions.
  

- **[TASK] Prepare `master` branch for next major `7.x`**
  After a short internal discussion the decision has been
  made to have `6.0.0` as only `6.x` version and phase it
  out and work towards new major `7.x`.
  
  Main reason for this decision is the fact, that it has
  been missed to remove deprecated functionality for the
  `6.0.0` release, which cannot be done not as `6.x` due
  to beeing breaking and violating `semver`.
  
  Used command(s):
  
  ```shell
  Build/Scripts/runTests.sh -p 8.2 -t 13 \
    -s composer -- config \
      "extra"."branch-alias"."dev-master" "7.x-dev"
  ```
  