### PR TITLE
Task/issue 42

### DIFF
--- a/Classes/Utility/AccessUtility.php
+++ b/Classes/Utility/AccessUtility.php
@@ -17,6 +17,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * @internal This class is only meant to be used inside EXT:xlsimport and therefore no public API.
  * Code can change anytime.
+ *
+ * @TODO refactor to a stateless, injected service
  */
 final class AccessUtility
 {

--- a/Classes/Utility/AccessUtility.php
+++ b/Classes/Utility/AccessUtility.php
@@ -20,8 +20,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 final class AccessUtility
 {
-    protected static DataHandler $dataHandler;
-
     /**
      * @throws UndefinedSchemaException
      */
@@ -63,7 +61,6 @@ final class AccessUtility
     {
         $tcaSchemeFactory = GeneralUtility::makeInstance(TcaSchemaFactory::class);
 
-        $dataHandler = self::$dataHandler ?? GeneralUtility::makeInstance(DataHandler::class);
         $schema = $tcaSchemeFactory->get($tableName);
         /** @var RootLevelCapability $rootLevelCapability */
         $rootLevelCapability = $schema->getCapability(TcaSchemaCapability::RestrictionRootLevel);
@@ -74,7 +71,7 @@ final class AccessUtility
         $allowed = false;
         // Check root-level
         if (!$pageId) {
-            if ($dataHandler->admin || $rootLevelCapability->shallIgnoreRootLevelRestriction()) {
+            if (self::getBackendUser()->isAdmin() || $rootLevelCapability->shallIgnoreRootLevelRestriction()) {
                 $allowed = true;
             }
             return $allowed;


### PR DESCRIPTION
[TASK] refactor AccessUtility

- removed dependency on DataHandler, as it was only used for checking if the user is admin, which is provided by `self::getBackendUser()->isAdmin()`
- added @TODO to refactor Class to a proper Service