### PR TITLE
[FIX] select `null` table

### DIFF
--- a/Classes/Controller/DataSheetImportController.php
+++ b/Classes/Controller/DataSheetImportController.php
@@ -141,7 +141,7 @@ final class DataSheetImportController
         $args = $request->getParsedBody();
         $encoding = (bool)($args['encoding'] ?? false);
         $deleteRecords = (bool)($args['deleteRecords'] ?? false);
-        $table = $args['table'];
+        $table = $args['table'] ?? '';
         $retry = (bool)($args['retry'] ?? false);
         $jsonFile = $args['jsonFile'] ?? '';
 


### PR DESCRIPTION
it is/was possible to "Upload" with empty table-selector
```
component="TYPO3.CMS.Core.Error.ProductionExceptionHandler"
: Core: Exception handler (WEB: BE): TypeError, code #0, file vendor/sudhaus7/xlsimport/Classes/Utility/AccessUtility.php, line 16
: SUDHAUS7\Xlsimport\Utility\AccessUtility::isAllowedTable(): Argument #1 ($possibleTable) must be of type string, null given
```